### PR TITLE
Update docs and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@ Ce répertoire contient deux parties :
 php -S 0.0.0.0:8080 -t server
 ```
 
+Créez d'abord les dossiers `server/apps` et `server/scripts` pour stocker les fichiers téléversés.
+
 Puis accédez à `http://localhost:8080/index.php` ou `http://localhost:8080/admin.php` pour la partie administration. L'interface d'administration permet maintenant de supprimer les applications existantes.
 
 ## Client Electron
+
+Avant de lancer le client, vous pouvez personnaliser l'URL du serveur en définissant la variable d'environnement `SKYONE_URL`.
+Par défaut le client ouvre `http://localhost:8080/index.php`.
 
 Voir les instructions dans `client/README.md`.

--- a/client/README.md
+++ b/client/README.md
@@ -10,6 +10,8 @@ npm install
 
 ## Lancement
 
+Définissez éventuellement la variable `SKYONE_URL` pour indiquer l'adresse du serveur.
+
 ```
-npm start
+SKYONE_URL=http://localhost:8080/index.php npm start
 ```

--- a/client/main.js
+++ b/client/main.js
@@ -9,6 +9,7 @@ function createWindow () {
       nodeIntegration: false
     }
   });
-  win.loadURL('https://172.19.21.125/index.php');
+  const url = process.env.SKYONE_URL || 'http://localhost:8080/index.php';
+  win.loadURL(url);
 }
 app.whenReady().then(createWindow);

--- a/server/download.php
+++ b/server/download.php
@@ -28,7 +28,10 @@ if(!$apps){
 
 $tmp = tempnam(sys_get_temp_dir(), 'apps');
 $zip = new ZipArchive();
-$zip->open($tmp, ZipArchive::OVERWRITE);
+if($zip->open($tmp, ZipArchive::OVERWRITE) !== true){
+  http_response_code(500);
+  exit('Erreur lors de la création de l\'archive');
+}
 foreach($apps as $app){
   $zip->addFile(__DIR__.'/apps/'.$app['file'], $app['file']);
   if(!empty($app['script'])){


### PR DESCRIPTION
## Summary
- add instructions for required folders and custom server URL
- let Electron client load server URL from `SKYONE_URL` env var
- mention URL customization in client README
- handle archive creation errors when downloading apps

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844697a67ec8327a28a1016bd7fe58c